### PR TITLE
Add in more features for presentation mode

### DIFF
--- a/_pages/presentation.html
+++ b/_pages/presentation.html
@@ -26,6 +26,38 @@ function getUrlParam(parameter, defaultvalue){
   return urlparameter;
 }
 
-var markdown = getUrlParam('markdown','.md').replace(/\.\./g, "0");;
-document.getElementById("markdown-slides").setAttribute("data-markdown", "./presentations/" + markdown); 
+// The following mode exists (ordered by priority):
+// - markdown : A presentation found in repository folder 'presentation'
+// - url      : A fully qualified URL
+// - gh-scope : A GitHub user/org and repository name. Ex: e-wu/test or sara-sabr/ITStrategy.
+//              Must be paired with gh-file.
+// - gh-file  : A GitHub file path to a md file. (Must be found in master by default)
+// - gh-branch: Another branch
+//
+function getMarkdownLocation() {
+  var urlArguments = getUrlVars();
+  var markdownLocation = "";  
+
+  if (urlArguments['markdown']) {
+    markdownLocation = urlArguments['markdown'];
+  } else if (urlArguments['url']) {
+    markdownLocation = urlArguments['url'];
+  } else if (urlArguments['gh-scope'] && urlArguments['gh-file']) {
+    var branch = urlArguments['gh-branch'] ?  urlArguments['gh-branch'] : 'master';
+    markdownLocation = "https://raw.githubusercontent.com/" + urlArguments['gh-scope'] + "/" + branch + "/" + urlArguments['gh-file'];
+  } else {
+    alert('Invalid markdown file provided.');
+    return "";
+  }
+
+  if (!(markdownLocation.endsWith(".md") || markdownLocation.endsWith(".MD"))) {
+    markdownLocation = markdownLocation + ".md";
+  }
+
+  return markdownLocation;
+}
+
+var mdFile = getMarkdownLocation();
+
+document.getElementById("markdown-slides").setAttribute("data-markdown", mdFile); 
 </script>

--- a/_pages/presentation.html
+++ b/_pages/presentation.html
@@ -39,7 +39,8 @@ function getMarkdownLocation() {
   var markdownLocation = "";  
 
   if (urlArguments['markdown']) {
-    markdownLocation = urlArguments['markdown'];
+    markdownLocation = urlArguments['markdown'].replace(/\.\./g, "0");
+    markdownLocation = "./presentations/" + markdownLocation;
   } else if (urlArguments['url']) {
     markdownLocation = urlArguments['url'];
   } else if (urlArguments['gh-scope'] && urlArguments['gh-file']) {
@@ -53,7 +54,7 @@ function getMarkdownLocation() {
   if (!(markdownLocation.endsWith(".md") || markdownLocation.endsWith(".MD"))) {
     markdownLocation = markdownLocation + ".md";
   }
-
+  
   return markdownLocation;
 }
 


### PR DESCRIPTION
The following mode exists (ordered by priority) and mode represents the parameters allowed when leveraging that feature:

| Param          | Mode | Description |
| ------------- | ------ | ------------- |
| markdown   |    1    | A presentation found in repository folder 'presentation' |
| url                |    2   | A fully qualified URL (Unescaped seems to work?) |
| gh-scope     |    3    | A GitHub user/org and repository name. Ex: e-wu/test or sara-sabr/ITStrategy. |
| gh-file         |    3    | A GitHub file path to a md file. (Assuming master by default, otherwise also pass in the branch parameter) |
| gh-branch | 3 | A GitHub branch name |

Example (while the branch still exists):
- https://e-wu.github.io/util-presentation/presentation.html?markdown=/en/2019-07-xx-Mandate.md
- https://e-wu.github.io/util-presentation/presentation.html?gh-scope=sara-sabr/ITStrategy&gh-file=presentations/en/2019-07-xx-Mandate.md
- https://e-wu.github.io/util-presentation/presentation.html?gh-scope=sara-sabr/ITStrategy&gh-file=presentations/en/Mandate.md&gh-branch=mandate-presentation
- https://e-wu.github.io/util-presentation/presentation.html?url=https://raw.githubusercontent.com/sara-sabr/ITStrategy/master/presentations/en/2019-07-xx-Mandate.md
- https://e-wu.github.io/util-presentation/presentation.html?markdown=en/2019-07-xx-Mandate.md

